### PR TITLE
correctly json_fail's msg key when raising an exption

### DIFF
--- a/plugins/module_utils/turbo/exceptions.py
+++ b/plugins/module_utils/turbo/exceptions.py
@@ -1,14 +1,14 @@
 class EmbeddedModuleFailure(Exception):
-    def __init__(self, message):
-        self._message = message
+    def __init__(self, msg):
+        self._message = msg
 
     def get_message(self):
         return repr(self._message)
 
 
 class EmbeddedModuleUnexpectedFailure(Exception):
-    def __init__(self, message):
-        self._message = message
+    def __init__(self, msg):
+        self._message = msg
 
     def get_message(self):
         return repr(self._message)

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -93,9 +93,9 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
             self.do_cleanup_files()
             raise EmbeddedModuleSuccess(**kwargs)
 
-    def fail_json(self, **kwargs):
+    def fail_json(self, *args, **kwargs):
         if not self.embedded_in_server:
             super().fail_json(**kwargs)
         else:
             self.do_cleanup_files()
-            raise EmbeddedModuleFailure(**kwargs)
+            raise EmbeddedModuleFailure(*args, **kwargs)

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -143,13 +143,13 @@ class EmbeddedModule:
             raise EmbeddedModuleFailure("No main() found!")
         try:
             if inspect.iscoroutinefunction(self.module_class.main):
-                print("Co routine!")
                 await self.module_class.main()
             else:
                 self.module_class.main()
         except EmbeddedModuleSuccess as e:
-            print("EmbeddedModuleSuccess!")
             return e.kwargs
+        except EmbeddedModuleFailure:
+            raise
         except Exception as e:
             backtrace = traceback.format_exc()
             raise EmbeddedModuleUnexpectedFailure(backtrace)


### PR DESCRIPTION
`EmbeddedModuleFailure` accepts now a `msg` key. This way, we
can directly pass `json_fail` arguments when we raise an exception.