### PR TITLE
Initialize sys_path_lock after the double fork()

### DIFF
--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -23,7 +23,7 @@ from .exceptions import (
     EmbeddedModuleSuccess,
 )
 
-sys_path_lock = asyncio.Lock()
+sys_path_lock = None
 
 import ansible.module_utils.basic
 
@@ -223,6 +223,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.fork:
         fork_process()
+    sys_path_lock = asyncio.Lock()
 
     server = AnsibleVMwareTurboMode()
     server.socket_path = args.socket_path


### PR DESCRIPTION
This change address a problem on MacOS.

If we create the asyncio lock before we do the double forks, it
actually initialize the asyncio context in the father process. And later
we get an "Bad file descriptor" when we try to start the asyncio endless
loop in the child process.

See: https://python-tornado.narkive.com/a9lCRPxp/errno-9-bad-file-descriptor#post2

Closes: #13