### PR TITLE
don't ignore parameter if value == False

### DIFF
--- a/changelogs/fragments/dont_ignore_parameters_when_val_is_False.yaml
+++ b/changelogs/fragments/dont_ignore_parameters_when_val_is_False.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- do not silently skip parameters when the value is ``False``

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -68,7 +68,11 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
         self.connect()
         result = dict(changed=False, original_message="", message="")
         ansiblez_path = sys.path[0]
-        args = {"ANSIBLE_MODULE_ARGS": {k: v for k, v in self.params.items() if v}}
+        args = {
+            "ANSIBLE_MODULE_ARGS": {
+                k: v for k, v in self.params.items() if v is not None
+            }
+        }
         data = [
             ansiblez_path,
             json.dumps(args),


### PR DESCRIPTION
A parameter with a `False` value can be a legit parameter that we want
to pass to the module.

See: https://github.com/ansible-collections/vmware.vmware_rest/issues/154