### PR TITLE
turbo_mode/doc: adjust the path of the socket

### DIFF
--- a/README_ansible_turbo.module.rst
+++ b/README_ansible_turbo.module.rst
@@ -134,6 +134,8 @@ You may want to manually start the server. This can be done with the following c
 
 .. code-block:: shell
 
-  PYTHONPATH=$HOME/.ansible/collections python -m ansible_collections.cloud.common.plugins.module_utils.turbo.server --socket-path $HOME/.ansible/tmp/turbo_mode.socket
+  PYTHONPATH=$HOME/.ansible/collections python -m ansible_collections.cloud.common.plugins.module_utils.turbo.server --socket-path $HOME/.ansible/tmp/turbo_mode.foo.bar.socket
+
+Replace ``foo.bar`` with the name of the collection.
 
 You can use the ``--help`` argument to get a list of the optional parameters.


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/684

Follow up to 24823345fbf4976b64e09775a01e627c84c4ddac, the socket
name now includes the name of the collection.