### PR TITLE
raise an error if exit_json or fail_json not called

### DIFF
--- a/changelogs/fragments/raise-an-error-if-exit_json-or-fail_json-not-called_13453.yaml
+++ b/changelogs/fragments/raise-an-error-if-exit_json-or-fail_json-not-called_13453.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- the user get an error now an error if a module don't raise ``exit_json()`` or ``fail_json()``.

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -157,6 +157,10 @@ class EmbeddedModule:
         except Exception as e:
             backtrace = traceback.format_exc()
             raise EmbeddedModuleUnexpectedFailure(backtrace)
+        else:
+            raise EmbeddedModuleUnexpectedFailure(
+                "Likely a bug: exit_json() or fail_json() should be called during the module excution"
+            )
 
 
 class AnsibleVMwareTurboMode:


### PR DESCRIPTION
`exit_json()` or `fail_json()` should always be called at the end of a
module execution. Since `ansible_module.turbo` relies on this to collect
the result, we now return a message if it's not the case.