### PR TITLE
Ensure fail_json() accepts **kwargs

### DIFF
--- a/changelogs/fragments/fail_json_accept_extra_kwargs.yaml
+++ b/changelogs/fragments/fail_json_accept_extra_kwargs.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- fail_json now accept and collect extra named arguments.

--- a/plugins/module_utils/turbo/exceptions.py
+++ b/plugins/module_utils/turbo/exceptions.py
@@ -1,6 +1,8 @@
 class EmbeddedModuleFailure(Exception):
-    def __init__(self, msg):
+    def __init__(self, msg, **kwargs):
         self._message = msg
+        if kwargs:
+            self._message += str(kwargs)
 
     def get_message(self):
         return repr(self._message)


### PR DESCRIPTION
Get `**kwargs` from `fail_json()` and pass the list to `EmbeddedModuleFailure` the
exception.