### PR TITLE
get the collection name from an attribute

### DIFF
--- a/changelogs/fragments/get_the_collection_name_from_an_attribute.yaml
+++ b/changelogs/fragments/get_the_collection_name_from_an_attribute.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- The modules must now set the ``collection_name`` of the ``AnsibleTurboModule`` class. The
+  content of this attribute is used to build the path of the UNIX socket.

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -15,7 +15,7 @@ if False:  # pylint: disable=using-constant-test
     please_include_me
 
 
-def collection_name():
+def get_collection_name_from_path():
     module_path = ansible.module_utils.basic.get_module_path()
 
     ansiblez = module_path.split("/")[-3]
@@ -69,19 +69,28 @@ def start_daemon(socket_path, ttl=None):
 
 class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
     embedded_in_server = False
+    collection_name = None
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._socket_path = (
-            os.environ["HOME"] + f"/.ansible/tmp/turbo_mode.{collection_name()}.socket"
+        self.collection_name = (
+            AnsibleTurboModule.collection_name or get_collection_name_from_path()
+        )
+        ansible.module_utils.basic.AnsibleModule.__init__(
+            self, *args, bypass_checks=True, **kwargs
         )
         self._running = None
         self.embedded_in_server = sys.argv[0].endswith("/server.py")
         if not self.embedded_in_server:
             self.run_on_daemon()
 
+    def socket_path(self):
+        return (
+            os.environ["HOME"]
+            + f"/.ansible/tmp/turbo_mode.{self.collection_name}.socket"
+        )
+
     def run_on_daemon(self):
-        _socket = connect(socket_path=self._socket_path)
+        _socket = connect(socket_path=self.socket_path())
         result = dict(changed=False, original_message="", message="")
         ansiblez_path = sys.path[0]
         args = {

--- a/plugins/modules/turbo_demo.py
+++ b/plugins/modules/turbo_demo.py
@@ -49,6 +49,7 @@ def run_module():
     # args/params passed to the execution, as well as if the module
     # supports check mode
     module = AnsibleModule(argument_spec={}, supports_check_mode=True)
+    module.collection_name = "cloud.common"
     if not module.check_mode:
         counter()
         result["changed"] = True


### PR DESCRIPTION
Use an attribute to know the name of the collection. The goal
is to phase out `get_collection_name_from_path()` later.