### PR TITLE
raise an exc is the output cannot be parsed

### DIFF
--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -5,7 +5,11 @@ import sys
 import time
 
 import ansible.module_utils.basic
-from .exceptions import EmbeddedModuleSuccess, EmbeddedModuleFailure
+from .exceptions import (
+    EmbeddedModuleSuccess,
+    EmbeddedModuleFailure,
+    EmbeddedModuleUnexpectedFailure,
+)
 
 if False:  # pylint: disable=using-constant-test
     from .server import please_include_me
@@ -107,8 +111,12 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
                 break
             raw_answer += b
         _socket.close()
-
-        result = json.loads(raw_answer.decode())
+        try:
+            result = json.loads(raw_answer.decode())
+        except json.decoder.JSONDecodeError:
+            raise EmbeddedModuleUnexpectedFailure(
+                f"Cannot decode module answer: {raw_answer}"
+            )
         self.exit_json(**result)
 
     def exit_json(self, **kwargs):


### PR DESCRIPTION
Raise an exception when we cannot parse the answer of the daemon.