### PR TITLE
debug: enable the profiler instance

### DIFF
--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -134,7 +134,8 @@ class EmbeddedModule:
         if self.debug_mode:
             import cProfile
 
-            return cProfile.Profile()
+            pr = cProfile.Profile()
+            pr.enable()
 
     def print_profiling_info(self, pr):
         if self.debug_mode:
@@ -213,8 +214,8 @@ class AnsibleVMwareTurboMode:
         ) = json.loads(raw_data)
         if self.debug_mode:
             print(  # pylint: disable=ansible-bad-function
-                f"-----\nrunning {ansiblez_path} with params: f{params}"
-            )  # pylint: disable=ansible-bad-function
+                f"-----\nrunning {ansiblez_path} with params: ¨{params}¨"
+            )
 
         embedded_module = EmbeddedModule(ansiblez_path, params)
         if self.debug_mode:


### PR DESCRIPTION
Ensure we enable the profile before we use it or we will trigger
an error with Python 3.9.