### PR TITLE
Don't run exception message through repr()

### DIFF
--- a/changelogs/fragments/46-fix-error-message-string.yaml
+++ b/changelogs/fragments/46-fix-error-message-string.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix exception messages containing extra single quotes (https://github.com/ansible-collections/cloud.common/pull/46).

--- a/plugins/module_utils/turbo/exceptions.py
+++ b/plugins/module_utils/turbo/exceptions.py
@@ -5,13 +5,13 @@ class EmbeddedModuleFailure(Exception):
             self._message += str(kwargs)
 
     def get_message(self):
-        return repr(self._message)
+        return self._message
 
     def __repr__(self):
-        return self.get_message()
+        return repr(self.get_message())
 
     def __str__(self):
-        return self.get_message()
+        return str(self.get_message())
 
 
 class EmbeddedModuleUnexpectedFailure(Exception):
@@ -19,13 +19,13 @@ class EmbeddedModuleUnexpectedFailure(Exception):
         self._message = msg
 
     def get_message(self):
-        return repr(self._message)
+        return self._message
 
     def __repr__(self):
-        return self.get_message()
+        return repr(self.get_message())
 
     def __str__(self):
-        return self.get_message()
+        return str(self.get_message())
 
 
 class EmbeddedModuleSuccess(Exception):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This causes all the error messages to be surrounded in single quotes.
Instead, `__repr__` should return repr() and `__str__` should return str().

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
