### PR TITLE
Fix premature socket closure

### DIFF
--- a/changelogs/fragments/socket-closure-fix.yaml
+++ b/changelogs/fragments/socket-closure-fix.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - turbo - make sure socket doesn't close prematurely, preventing issues with
+    large amounts of data passed as module parameters
+    (https://github.com/ansible-collections/cloud.common/issues/61)

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -147,7 +147,8 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
             ansiblez_path,
             json.dumps(args),
         ]
-        _socket.send(json.dumps(data).encode())
+        _socket.sendall(json.dumps(data).encode())
+        _socket.shutdown(socket.SHUT_WR)
         raw_answer = b""
         while True:
             b = _socket.recv((1024 * 1024))

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -205,7 +205,7 @@ class AnsibleVMwareTurboMode:
     async def handle(self, reader, writer):
         self._watcher.cancel()
 
-        raw_data = await reader.read(1024 * 10)
+        raw_data = await reader.read()
         if not raw_data:
             return
 


### PR DESCRIPTION
AnsibleTurboModule had some bugs that manifested when large input data
were sent over the socket (greater than the hardcoded limit of 102400
bytes). This is uncommon, but in particular the kubernetes.core.k8s
module sends relatively large amounts of data as module arguments over
the socket connection, which triggers this bug.

The server was reading, at most, 102400 bytes of data. asyncio's
StreamReader.read(), with no arguments, will read until the End of File
is reached, so we add the `socket.shutdown` call to the client to send
an EOF. This closes the socket for writing, which is fine, since at this
point, all remaining communication flows from server to client.

Additionally, `socket.sendall` replaces `socket.send`, which does not
guarantee the whole message will be sent in one attempt:

 > Returns the number of bytes sent. Applications are responsible for
 > checking that all data has been sent; if only some of the data was
 > transmitted, the application needs to attempt delivery of the
 > remaining data.

Fixes ansible-collections/cloud.common#61
Fixes ansible-collections/kubernetes.core#140

Co-Authored-By: Jeff Smith <toxicglados@gmail.com>

##### ISSUE TYPE
- Bugfix Pull Request
