### PR TITLE
Respect the remote_tmp setting

### DIFF
--- a/changelogs/fragments/Respect_the_remote_tmp_setting.yaml
+++ b/changelogs/fragments/Respect_the_remote_tmp_setting.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- turbo - honor the ``remote_tmp`` configuration key.

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -43,8 +43,8 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
 
     def socket_path(self):
         return (
-            os.environ["HOME"]
-            + f"/.ansible/tmp/turbo_mode.{self.collection_name}.socket"
+            self._remote_tmp
+            + f"/turbo_mode.{self.collection_name}.socket"
         )
 
     def _get_argument_specs(self):

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -42,10 +42,10 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
             self.run_on_daemon()
 
     def socket_path(self):
-        return (
-            self._remote_tmp
-            + f"/turbo_mode.{self.collection_name}.socket"
-        )
+        from os.path import expanduser
+
+        abs_remote_tmp = expanduser(self._remote_tmp)
+        return abs_remote_tmp + f"/turbo_mode.{self.collection_name}.socket"
 
     def _get_argument_specs(self):
         """Returns a dict of accepted argument that includes the aliases"""

--- a/tests/integration/targets/turbo_mode/tasks/main.yaml
+++ b/tests/integration/targets/turbo_mode/tasks/main.yaml
@@ -65,3 +65,11 @@
 - assert:
     that:
       - _result.counter == 1
+
+- name: test using default remote_tmp. socket previously created
+  cloud.common.turbo_demo:
+  register: _result
+
+- assert:
+        that:
+        - _result.counter > 1

--- a/tests/integration/targets/turbo_mode/tasks/main.yaml
+++ b/tests/integration/targets/turbo_mode/tasks/main.yaml
@@ -49,3 +49,19 @@
 - assert:
     that:
       - not _result.envvar
+
+
+- name: Create temporary dir
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: temp
+  register: tempdir_1
+
+- name: Test with a different remote_tmp, there is no socket yet.
+  cloud.common.turbo_demo:
+  vars:
+    ansible_remote_tmp: "{{ tempdir_1.path }}"
+  register: _result
+- assert:
+    that:
+      - _result.counter == 1


### PR DESCRIPTION
##### SUMMARY
This PR makes the turbo module respect custom remote Ansible temporary directories set by the `remote_tmp` setting in `ansible.cfg` or by the `ANSIBLE_REMOTE_TMP` environment variable.
This is necessary because in its current state the module will always try to create a socket in the default `$HOME/.ansible/tmp` temporary directory which may be missing if a custom `remote_tmp` is set.

##### ISSUE TYPE
- Bugfix Pull Request
