### PR TITLE
AnsibleTurboModule does transfer all AnsibleModule variable to the socket

### DIFF
--- a/changelogs/fragments/reading-common-variable.yaml
+++ b/changelogs/fragments/reading-common-variable.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - turbo - AnsibleTurboModule was missing some _ansible_facts variable like _diff, _ansible_tmpdir. (https://github.com/ansible-collections/cloud.common/issues/65)

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -131,9 +131,10 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
                 new_params[k] = v
         args = {"ANSIBLE_MODULE_ARGS": new_params}
         for k in ansible.module_utils.basic.PASS_VARS:
-            if not hasattr(self, k):
+            attribute = ansible.module_utils.basic.PASS_VARS[k][0]
+            if not hasattr(self, attribute):
                 continue
-            v = getattr(self, k)
+            v = getattr(self, attribute)
             if isinstance(v, int) or isinstance(v, bool) or isinstance(v, str):
                 args["ANSIBLE_MODULE_ARGS"][f"_ansible_{k}"] = v
         return args

--- a/plugins/modules/turbo_demo.py
+++ b/plugins/modules/turbo_demo.py
@@ -50,11 +50,15 @@ def run_module():
     # supports check mode
     module = AnsibleModule(argument_spec={}, supports_check_mode=True)
     module.collection_name = "cloud.common"
+    previous_value = counter.i
     if not module.check_mode:
         counter()
         result["changed"] = True
     result["message"] = get_message()
     result["counter"] = counter.i
+
+    if module._diff:
+        result["diff"] = {"before": previous_value, "after": counter.i}
 
     module.exit_json(**result)
 

--- a/tests/integration/targets/turbo_mode/tasks/main.yaml
+++ b/tests/integration/targets/turbo_mode/tasks/main.yaml
@@ -19,3 +19,15 @@
 - assert:
     that:
       - _result.results[-1].counter == 10
+- cloud.common.turbo_demo:
+  diff: yes
+  register: _result_with_diff
+- assert:
+    that:
+      - _result_with_diff.diff is defined
+- cloud.common.turbo_demo:
+  diff: no
+  register: _result_no_diff
+- assert:
+    that:
+      - _result_no_diff.diff is undefined


### PR DESCRIPTION
``PASS_VARS`` is dict with each data item defined as a 2-tuple with first item corresponding to the attribute to the AnsibleModule class.

Consequently, only the ``check_mode`` was copied as this is the only variable with the same name on both the tuple and the ``PASS_VARS`` key.
