### PR TITLE
Add exception handler for loop

### DIFF
--- a/changelogs/fragments/67-add-exception-handler.yaml
+++ b/changelogs/fragments/67-add-exception-handler.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - add exception handler to main async loop (https://github.com/ansible-collections/cloud.common/pull/67).

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -241,9 +241,15 @@ class AnsibleVMwareTurboMode:
 
         await embedded_module.unload()
 
+    def handle_exception(self, loop, context):
+        e = context.get("exception")
+        traceback.print_exception(type(e), e, e.__traceback__)
+        self.stop()
+
     def start(self):
         self.loop = asyncio.get_event_loop()
         self.loop.add_signal_handler(signal.SIGTERM, self.stop)
+        self.loop.set_exception_handler(self.handle_exception)
         self._watcher = self.loop.create_task(self.ghost_killer())
 
         import sys


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The async loop had no exception handler attached besides the default.
This would cause the server to hang when an unhandled exception
occurred.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
