### PR TITLE
add a parameter to turn off turbo mode

### DIFF
--- a/README_ansible_turbo.module.rst
+++ b/README_ansible_turbo.module.rst
@@ -147,6 +147,10 @@ You can raise ``EmbeddedModuleFailure`` exception yourself, for instance from a 
     Not only they are bad practice, but also may interface with this
     mechanism.
 
+How can I disable it by default?
+================================
+
+You can turn off the cache by default by adding a new `enable_session_cache` argument to your module. If the value is `False`, the turbo mode will be disabled.
 
 Troubleshooting
 ===============

--- a/changelogs/fragments/add_enable_session_cache_default_parameter.yaml
+++ b/changelogs/fragments/add_enable_session_cache_default_parameter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - turbo - Add support for the enable_session_cache parameter. This optional parameter can be used to turn off the turbo mode by default.

--- a/plugins/doc_fragments/turbo_options.py
+++ b/plugins/doc_fragments/turbo_options.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Options for selecting or identifying a specific K8s object
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  enable_session_cache:
+    description:
+    - Enable the caching of the HTTP sessions.
+    type: bool
+    default: true
+'''

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -29,14 +29,22 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
     embedded_in_server = False
     collection_name = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, argument_spec=None, **kwargs):
+        if not argument_spec:
+            argument_spec = {}
         self.embedded_in_server = sys.argv[0].endswith("/server.py")
         self.collection_name = (
             AnsibleTurboModule.collection_name or get_collection_name_from_path()
         )
         ansible.module_utils.basic.AnsibleModule.__init__(
-            self, *args, bypass_checks=not self.embedded_in_server, **kwargs
+            self,
+            *args,
+            bypass_checks=not self.embedded_in_server,
+            argument_spec=argument_spec,
+            **kwargs,
         )
+        if "enable_session_cache" in self.params and not self.params["enable_session_cache"]:
+            return
         self._running = None
         if not self.embedded_in_server:
             self.run_on_daemon()

--- a/plugins/modules/turbo_demo.py
+++ b/plugins/modules/turbo_demo.py
@@ -13,6 +13,8 @@ description:
 - "This module is an example of an ansible_module.turbo integration"
 author:
 - Gonéri Le Bouder (@goneri)
+extends_documentation_fragment:
+- cloud.common.turbo_options
 """
 
 EXAMPLES = r"""
@@ -48,7 +50,14 @@ def run_module():
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module
     # supports check mode
-    module = AnsibleModule(argument_spec={}, supports_check_mode=True)
+    argument_spec = {}
+    argument_spec["enable_session_cache"] = {
+        "type": "bool",
+        "default": True,
+        "required": False,
+    }
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     module.collection_name = "cloud.common"
     previous_value = counter.i
     if not module.check_mode:

--- a/tests/integration/targets/turbo_mode/tasks/main.yaml
+++ b/tests/integration/targets/turbo_mode/tasks/main.yaml
@@ -19,6 +19,16 @@
 - assert:
     that:
       - _result.results[-1].counter == 10
+- name: "Ensure we don't use the cache if enable_session_cache is false"
+  cloud.common.turbo_demo:
+    enable_session_cache: false
+  with_sequence: count=10
+  become: true
+  register: _result
+- assert:
+    that:
+      - _result.results[-1].counter == 1
+      - _result.results[-2].counter == 1
 - cloud.common.turbo_demo:
   diff: yes
   register: _result_with_diff
@@ -73,3 +83,13 @@
 - assert:
         that:
         - _result.counter > 1
+
+
+- name: Ensure we can disable the turbo mode
+  cloud.common.turbo_demo:
+    enable_session_cache: false
+  with_sequence: count=10
+  register: _result
+- assert:
+    that:
+      - _result.results[-1].counter == 1


### PR DESCRIPTION
Disable the turbo mode when:
- the module exposes a `enable_session_cache` params and
- the parameter is False.