### PR TITLE
prepare 2.0.4 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,22 @@ cloud.common Release Notes
 .. contents:: Topics
 
 
+v2.0.4
+======
+
+Major Changes
+-------------
+
+- turbo - enable turbo mode for lookup plugins
+
+Bugfixes
+--------
+
+- add exception handler to main async loop (https://github.com/ansible-collections/cloud.common/pull/67).
+- pass current task's environment through to execution (https://github.com/ansible-collections/cloud.common/pull/69).
+- turbo - AnsibleTurboModule was missing some _ansible_facts variable like _diff, _ansible_tmpdir. (https://github.com/ansible-collections/cloud.common/issues/65)
+- turbo - honor the ``remote_tmp`` configuration key.
+
 v2.0.3
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -77,3 +77,20 @@ releases:
     - py3.10-fix.yaml
     - socket-closure-fix.yaml
     release_date: '2021-06-22'
+  2.0.4:
+    changes:
+      bugfixes:
+      - add exception handler to main async loop (https://github.com/ansible-collections/cloud.common/pull/67).
+      - pass current task's environment through to execution (https://github.com/ansible-collections/cloud.common/pull/69).
+      - turbo - AnsibleTurboModule was missing some _ansible_facts variable like _diff,
+        _ansible_tmpdir. (https://github.com/ansible-collections/cloud.common/issues/65)
+      - turbo - honor the ``remote_tmp`` configuration key.
+      major_changes:
+      - turbo - enable turbo mode for lookup plugins
+    fragments:
+    - 67-add-exception-handler.yaml
+    - 69-pass-envvar.yaml
+    - Respect_the_remote_tmp_setting.yaml
+    - reading-common-variable.yaml
+    - turbo-for-lookup-plugin.yaml
+    release_date: '2021-07-29'

--- a/changelogs/fragments/67-add-exception-handler.yaml
+++ b/changelogs/fragments/67-add-exception-handler.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - add exception handler to main async loop (https://github.com/ansible-collections/cloud.common/pull/67).

--- a/changelogs/fragments/69-pass-envvar.yaml
+++ b/changelogs/fragments/69-pass-envvar.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - pass current task's environment through to execution (https://github.com/ansible-collections/cloud.common/pull/69).

--- a/changelogs/fragments/Respect_the_remote_tmp_setting.yaml
+++ b/changelogs/fragments/Respect_the_remote_tmp_setting.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-- turbo - honor the ``remote_tmp`` configuration key.

--- a/changelogs/fragments/reading-common-variable.yaml
+++ b/changelogs/fragments/reading-common-variable.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - turbo - AnsibleTurboModule was missing some _ansible_facts variable like _diff, _ansible_tmpdir. (https://github.com/ansible-collections/cloud.common/issues/65)

--- a/changelogs/fragments/turbo-for-lookup-plugin.yaml
+++ b/changelogs/fragments/turbo-for-lookup-plugin.yaml
@@ -1,3 +1,0 @@
----
-major_changes:
-  - turbo - enable turbo mode for lookup plugins


### PR DESCRIPTION
Major Changes
-------------

- turbo - enable turbo mode for lookup plugins

Bugfixes
--------

- add exception handler to main async loop (https://github.com/ansible-collections/cloud.common/pull/67).
- pass current task's environment through to execution (https://github.com/ansible-collections/cloud.common/pull/69).
- turbo - AnsibleTurboModule was missing some _ansible_facts variable like _diff, _ansible_tmpdir. (https://github.com/ansible-collections/cloud.common/issues/65)
- turbo - honor the ``remote_tmp`` configuration key.