### PR TITLE
ensure only the minimal amount of modules are loading during the first stage

### DIFF
--- a/changelogs/fragments/too_many_loaded_modules.yaml
+++ b/changelogs/fragments/too_many_loaded_modules.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Ensure only the minimal amount of modules are loading during the first stage.

--- a/plugins/module_utils/turbo/exceptions.py
+++ b/plugins/module_utils/turbo/exceptions.py
@@ -34,3 +34,7 @@ class EmbeddedModuleUnexpectedFailure(Exception):
 class EmbeddedModuleSuccess(Exception):
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+
+
+class TooManyLoadedModules(EmbeddedModuleUnexpectedFailure):
+    pass

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -6,6 +6,7 @@ import ansible.module_utils.basic
 from .exceptions import (
     EmbeddedModuleSuccess,
     EmbeddedModuleFailure,
+    TooManyLoadedModules,
 )
 import ansible_collections.cloud.common.plugins.module_utils.turbo.common
 
@@ -80,6 +81,14 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
         )
         self._running = None
         if not self.embedded_in_server:
+            external_libs = [
+                name
+                for name in sys.modules
+                if "site-packages" in str(sys.modules[name])
+                and name not in ["_virtualenv", "distro", "ansible.module_utils.distro"]
+            ]
+            if external_libs:
+                raise TooManyLoadedModules(external_libs)
             self.run_on_daemon()
 
     def socket_path(self):


### PR DESCRIPTION
Turbo mode works in two stages.

- 1. load the AnsibleTurboModule which while spawn the background process
- 2. continue the execution in the background process

All the heavy operations should be done in the background process, this include the loading
of libraries.

With this PR, we raise an exception if a third party module is loaded during the first stage. This will help the developers to properly delay the loading of the dependencies.