### PR TITLE
Update socket location calculation

### DIFF
--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -27,7 +27,9 @@
 #
 import json
 import os
+import os.path
 import sys
+import tempfile
 
 import ansible.module_utils.basic
 from .exceptions import (
@@ -117,10 +119,11 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
             self.run_on_daemon()
 
     def socket_path(self):
-        from os.path import expanduser
-
-        abs_remote_tmp = expanduser(self._remote_tmp)
-        return abs_remote_tmp + f"/turbo_mode.{self.collection_name}.socket"
+        if self._remote_tmp is None:
+            abs_remote_tmp = tempfile.gettempdir()
+        else:
+            abs_remote_tmp = os.path.expanduser(os.path.expandvars(self._remote_tmp))
+        return os.path.join(abs_remote_tmp, f"turbo_mode.{self.collection_name}.socket")
 
     def init_args(self):
         argument_specs = expand_argument_specs_aliases(self.argument_spec)

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -62,3 +62,7 @@ plugins/module_utils/turbo/common.py import-2.6!skip
 plugins/module_utils/turbo/common.py import-2.7!skip
 plugins/module_utils/turbo/common.py import-3.5!skip
 plugins/module_utils/turbo/common.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py metaclass-boilerplate!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -70,3 +70,7 @@ plugins/module_utils/turbo/common.py import-2.6!skip
 plugins/module_utils/turbo/common.py import-2.7!skip
 plugins/module_utils/turbo/common.py import-3.5!skip
 plugins/module_utils/turbo/common.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py metaclass-boilerplate!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -46,3 +46,7 @@ plugins/module_utils/turbo/common.py import-3.5!skip
 plugins/module_utils/turbo/common.py metaclass-boilerplate!skip
 plugins/modules/turbo_demo.py validate-modules!skip
 plugins/modules/turbo_fail.py validate-modules!skip
+tests/unit/plugins/module_utils/turbo/conftest.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py metaclass-boilerplate!skip

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -35,3 +35,7 @@ plugins/module_utils/turbo/common.py import-3.5!skip
 plugins/module_utils/turbo/common.py metaclass-boilerplate!skip
 plugins/modules/turbo_demo.py validate-modules!skip
 plugins/modules/turbo_fail.py validate-modules!skip
+tests/unit/plugins/module_utils/turbo/conftest.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py metaclass-boilerplate!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -62,3 +62,7 @@ plugins/module_utils/turbo/common.py import-2.6!skip
 plugins/module_utils/turbo/common.py import-2.7!skip
 plugins/module_utils/turbo/common.py import-3.5!skip
 plugins/module_utils/turbo/common.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/conftest.py metaclass-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py future-import-boilerplate!skip
+tests/unit/plugins/module_utils/turbo/test_module.py metaclass-boilerplate!skip

--- a/tests/unit/plugins/module_utils/turbo/conftest.py
+++ b/tests/unit/plugins/module_utils/turbo/conftest.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 XLAB Steampunk
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+
+@pytest.fixture
+def set_module_args(monkeypatch):
+    def wrapper(args=None):
+        module_args = dict(ANSIBLE_MODULE_ARGS=args or {})
+        monkeypatch.setattr(basic, "_ANSIBLE_ARGS", to_bytes(json.dumps(module_args)))
+
+    return wrapper

--- a/tests/unit/plugins/module_utils/turbo/test_module.py
+++ b/tests/unit/plugins/module_utils/turbo/test_module.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 XLAB Steampunk
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import sys
+
+import pytest
+
+from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+    AnsibleTurboModule,
+)
+
+
+def _patch_globals(monkeypatch):
+    # Patch sys.argv so that module does not try to spin up the server on
+    # initialization. The purpose is to make sure AnsibleTurboModule.embedded_in_server
+    # is set to True.
+    monkeypatch.setattr(sys, "argv", ["something/that/ends/on/server.py"])
+
+    # Collection name detection will fail in unit tests, so we patch it here directly
+    # and bypass the detection process.
+    monkeypatch.setattr(AnsibleTurboModule, "collection_name", "namespace.name")
+
+
+def test_module_socket_path_remote_tmp_not_set(monkeypatch, set_module_args):
+    _patch_globals(monkeypatch)
+    set_module_args()
+    module = AnsibleTurboModule(argument_spec={})
+
+    path = module.socket_path()
+
+    # We cannot know what tmp dir python uses, but we do know that it is a full path
+    # that ends with deterministc suffix.
+    assert path.startswith("/")
+    assert path.endswith("/turbo_mode.namespace.name.socket")
+
+
+@pytest.mark.parametrize("tmp_path", ["/tmp", "/tmp/"])
+def test_module_socket_path_from_remote_tmp(monkeypatch, set_module_args, tmp_path):
+    _patch_globals(monkeypatch)
+    set_module_args(dict(_ansible_remote_tmp=tmp_path))
+    module = AnsibleTurboModule(argument_spec={})
+
+    assert module.socket_path() == "/tmp/turbo_mode.namespace.name.socket"
+
+
+@pytest.mark.parametrize(
+    "tmp_path", ["/t/$MY_VAR", "/t/${MY_VAR}", "/t/$MY_VAR/", "/t/${MY_VAR}/"]
+)
+def test_module_socket_path_env_vars_in_remote_tmp(
+    monkeypatch, set_module_args, tmp_path
+):
+    _patch_globals(monkeypatch)
+    set_module_args(dict(_ansible_remote_tmp=tmp_path))
+    monkeypatch.setenv("MY_VAR", "my_var_value")
+    module = AnsibleTurboModule(argument_spec={})
+
+    assert module.socket_path() == "/t/my_var_value/turbo_mode.namespace.name.socket"


### PR DESCRIPTION
##### SUMMARY

Turbo modules rely on core Ansible mechanism for temporary path creation on the target host. This means that the socket path calculation must be in sync with the core calculation.

Up until now, turbo modules only handled one happy path: where remote tmp location was set, it did not include any environment variables that would need to be expanded, and it did not have a trailing slash.

This commit brings the core and turbo modules in sync when it comes to remote temporary location calculations and adds a few tests to make sure things work as expected.

Fixes https://github.com/ansible-collections/vmware.vmware_rest/issues/262

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

AnsibleTurboModule