### PR TITLE
Fix parameters with aliases not being passed

### DIFF
--- a/changelogs/fragments/92-fix-params-with-aliases.yml
+++ b/changelogs/fragments/92-fix-params-with-aliases.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix parameters with aliases not being passed through (https://github.com/ansible-collections/cloud.common/issues/91).

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -80,7 +80,7 @@ def prepare_args(argument_specs, params):
 
     def _is_an_alias(k):
         aliases = argument_specs[k].get("aliases")
-        return aliases and k != aliases[0]
+        return aliases and k in aliases
 
     new_params = {}
     for k, v in params.items():

--- a/tests/unit/module_utils/test_turbo_module.py
+++ b/tests/unit/module_utils/test_turbo_module.py
@@ -131,7 +131,14 @@ def test_prepare_args_subkey_with_default():
 def test_prepare_args_dedup_aliases():
     argspec = {
         "foo": {"aliases": ["bar"], "type": int},
-        "bar": {"aliases": ["bar"], "type": int},
     }
     params = {"foo": 1, "bar": 1}
-    assert prepare_args(argspec, params) == {"ANSIBLE_MODULE_ARGS": {"bar": 1}}
+    assert prepare_args(argspec, params) == {"ANSIBLE_MODULE_ARGS": {"foo": 1}}
+
+
+def test_prepare_args_with_aliases():
+    argspec = {
+        "foo": {"aliases": ["bar"], "type": int}
+    }
+    params = {"foo": 1}
+    assert prepare_args(argspec, params) == {"ANSIBLE_MODULE_ARGS": {"foo": 1}}

--- a/tests/unit/module_utils/test_turbo_module.py
+++ b/tests/unit/module_utils/test_turbo_module.py
@@ -129,16 +129,12 @@ def test_prepare_args_subkey_with_default():
 
 
 def test_prepare_args_dedup_aliases():
-    argspec = {
-        "foo": {"aliases": ["bar"], "type": int},
-    }
+    argspec = {"foo": {"aliases": ["bar"], "type": int}}
     params = {"foo": 1, "bar": 1}
     assert prepare_args(argspec, params) == {"ANSIBLE_MODULE_ARGS": {"foo": 1}}
 
 
 def test_prepare_args_with_aliases():
-    argspec = {
-        "foo": {"aliases": ["bar"], "type": int}
-    }
+    argspec = {"foo": {"aliases": ["bar"], "type": int}}
     params = {"foo": 1}
     assert prepare_args(argspec, params) == {"ANSIBLE_MODULE_ARGS": {"foo": 1}}


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The recently added _is_an_alias() function should check whether the
current key is in the list of aliases.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #91 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
