### PR TITLE
WIP - display error in output when server failed to start

### DIFF
--- a/changelogs/fragments/start_server_log.yaml
+++ b/changelogs/fragments/start_server_log.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - capture stdout and stderr content when process failed to start turbo server (https://github.com/ansible-collections/cloud.common/pull/128).

--- a/plugins/module_utils/turbo/common.py
+++ b/plugins/module_utils/turbo/common.py
@@ -55,8 +55,7 @@ class AnsibleTurboSocket:
                 return True
             except (ConnectionRefusedError, FileNotFoundError):
                 if not running:
-                    start_server_error = self.start_server()
-                    running = start_server_error is None
+                    running, start_server_error = self.start_server()
                 if attempt == 0:
                     if not running:
                         raise EmbeddedModuleUnexpectedFailure(
@@ -98,10 +97,9 @@ class AnsibleTurboSocket:
             stderr=subprocess.PIPE,
         )
         out, err = p.communicate()
-        if p.returncode != 0:
-            return "stdout='{0}' stderr='{1}'".format(
-                out.decode("utf-8"), err.decode("utf-8")
-            )
+        return p.returncode == 0, "stdout='{0}' stderr='{1}'".format(
+            out.decode("utf-8"), err.decode("utf-8")
+        )
 
     def communicate(self, data, wait_sleep=0.01):
         encoded_data = pickle.dumps((self._plugin, data))

--- a/plugins/module_utils/turbo/module.py
+++ b/plugins/module_utils/turbo/module.py
@@ -35,6 +35,7 @@ import ansible.module_utils.basic
 from .exceptions import (
     EmbeddedModuleSuccess,
     EmbeddedModuleFailure,
+    EmbeddedModuleUnexpectedFailure,
 )
 import ansible_collections.cloud.common.plugins.module_utils.turbo.common
 
@@ -140,19 +141,22 @@ class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
     def run_on_daemon(self):
         result = dict(changed=False, original_message="", message="")
         ttl = os.environ.get("ANSIBLE_TURBO_LOOKUP_TTL", None)
-        with ansible_collections.cloud.common.plugins.module_utils.turbo.common.connect(
-            socket_path=self.socket_path(), ttl=ttl
-        ) as turbo_socket:
-            ansiblez_path = sys.path[0]
-            args = self.init_args()
-            data = [
-                ansiblez_path,
-                json.dumps(args),
-                dict(os.environ),
-            ]
-            content = json.dumps(data).encode()
-            result = turbo_socket.communicate(content)
-        self.exit_json(**result)
+        try:
+            with ansible_collections.cloud.common.plugins.module_utils.turbo.common.connect(
+                socket_path=self.socket_path(), ttl=ttl
+            ) as turbo_socket:
+                ansiblez_path = sys.path[0]
+                args = self.init_args()
+                data = [
+                    ansiblez_path,
+                    json.dumps(args),
+                    dict(os.environ),
+                ]
+                content = json.dumps(data).encode()
+                result = turbo_socket.communicate(content)
+            self.exit_json(**result)
+        except EmbeddedModuleUnexpectedFailure as err:
+            self.fail_json(msg=str(err))
 
     def exit_json(self, **kwargs):
         if not self.embedded_in_server:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the server start errors are not returned to the end user making hard to debug running issue.
This pull requests helps debugging by capturing shell command logs.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
**Note**: *This piece of code will display log information for socket creation, there is no risk to display session credentials or any secured data as this happens later on the process.*

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
turbo daemon
