### PR TITLE
Move turbo server import statements into try/except block

### DIFF
--- a/changelogs/fragments/20240103-module_utils-turbo-server-import-fix.yaml.yaml
+++ b/changelogs/fragments/20240103-module_utils-turbo-server-import-fix.yaml.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - module_utils/turbo/server - Ensure all import statements in run_as_lookup_plugin() are in a try/except block (https://github.com/ansible-collections/cloud.common/pull/143).

--- a/changelogs/fragments/20240103-module_utils-turbo-server-import-fix.yaml.yaml
+++ b/changelogs/fragments/20240103-module_utils-turbo-server-import-fix.yaml.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
-  - module_utils/turbo/server - Ensure all import statements in run_as_lookup_plugin() are in a try/except block (https://github.com/ansible-collections/cloud.common/pull/143).
+  - module_utils/turbo/server - Ensure all import statements in run_as_lookup_plugin() are in a try/except block
+    (https://github.com/ansible-collections/cloud.common/pull/143).

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -222,14 +222,18 @@ class EmbeddedModule:
 
 async def run_as_lookup_plugin(data):
     errors = None
-    from ansible.module_utils._text import to_native
-
     result = None
+
     try:
         import ansible.plugins.loader as plugin_loader
+        from ansible.module_utils._text import to_native
         from ansible.parsing.dataloader import DataLoader
         from ansible.template import Templar
+    except ImportError as e:
+        errors = str(e)
+        return [result, errors]
 
+    try:
         (
             lookup_name,
             terms,


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where one import statement was outside the try/except block in the turbo server run_as_lookup_plugin() function. Because this is run in an async loop inside a subprocess, unhandled exceptions can cause strange behavior so it's better to have all the import statements in a try/except block that returns error messages to the user.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils.turbo.server