### PR TITLE
Revert "Update docs links after branching stable-4"

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -2,7 +2,7 @@
 
 ##  cloud.common Collection
 
-GitHub Actions are used to run the Continuous Integration for ansible-collections/cloud.common collection. The workflows used for the CI can be found [here](https://github.com/ansible-collections/cloud.common/tree/stable-4/.github/workflows). These workflows include jobs to run the unit tests, sanity tests, linters and changelog check. The following table lists the python and ansible versions against which these jobs are run.
+GitHub Actions are used to run the Continuous Integration for ansible-collections/cloud.common collection. The workflows used for the CI can be found [here](https://github.com/ansible-collections/cloud.common/tree/main/.github/workflows). These workflows include jobs to run the unit tests, sanity tests, linters and changelog check. The following table lists the python and ansible versions against which these jobs are run.
 
 | Jobs | Description | Python Versions | Ansible Versions |
 | ------ |-------| ------ | -----------|

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ You can use the `--help` argument to get a list of the optional parameters.
 
 ## Release notes
 
-See [CHANGELOG.rst](https://github.com/ansible-collections/cloud.common/blob/stable-4/CHANGELOG.rst).
+See [CHANGELOG.rst](https://github.com/ansible-collections/cloud.common/blob/main/CHANGELOG.rst).
 
 ## Testing, Releasing, Versioning and Deprecation
 
-This collection is tested using GitHub Actions. To know more about CI, refer to [CI.md](https://github.com/ansible-collections/cloud.common/blob/stable-4/CI.md).
+This collection is tested using GitHub Actions. To know more about CI, refer to [CI.md](https://github.com/ansible-collections/cloud.common/blob/main/CI.md).
 
 This collection follows [Semantic Versioning](https://semver.org/). More details on versioning can be found [in the Ansible docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#collection-versions).
 


### PR DESCRIPTION
The PR has been issued against the wrong branch.
Reverts ansible-collections/cloud.common#152

The PR has been re-opened against the stable-4 branch this time https://github.com/ansible-collections/cloud.common/pull/155