### PR TITLE
update async loop creation for python 3.12 and higher

### DIFF
--- a/changelogs/fragments/168-python-312-async-support.yml
+++ b/changelogs/fragments/168-python-312-async-support.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    plugins/module_utils/turbo/server - Update how the async loop is created to support
+    python 3.12+ (https://github.com/ansible-collections/cloud.common/pull/168).

--- a/plugins/module_utils/turbo/server.py
+++ b/plugins/module_utils/turbo/server.py
@@ -364,7 +364,8 @@ class AnsibleVMwareTurboMode:
         self.stop()
 
     def start(self):
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
         self.loop.add_signal_handler(signal.SIGTERM, self.stop)
         self.loop.set_exception_handler(self.handle_exception)
         self._watcher = self.loop.create_task(self.ghost_killer())
@@ -390,7 +391,10 @@ class AnsibleVMwareTurboMode:
                     self.handle, path=self.socket_path, loop=self.loop
                 )
             )
-        self.loop.run_forever()
+        try:
+            self.loop.run_forever()
+        finally:
+            self.loop.close()
 
     def stop(self):
         os.unlink(self.socket_path)


### PR DESCRIPTION
##### SUMMARY
Update how the async loop is created to support python 3.12+. In these versions of python, accessing the default loop is deprecated and you must create your own

Fixes https://github.com/ansible-collections/cloud.common/issues/164

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/turbo/server
